### PR TITLE
INLINABLE insert and delete, bench, small doc additions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.swp
+cabal.project.local*
+dist-newstyle

--- a/bench/Cuckoo.hs
+++ b/bench/Cuckoo.hs
@@ -67,7 +67,7 @@ memberBench label n cf xs = bench (label <> " - " <> show n) $ whnfIO f
   where
     f = fmap length (filterM (member cf) xs)
 
-#ifdef RARANDOM_STANDARD
+#ifdef RANDOM_STANDARD
 deleteBench :: String -> Int -> CuckooFilter (PrimState IO) 4 10 Int -> [Int] -> Benchmark
 deleteBench label n cf0 xs = bench (label <> " - " <> show n) $ whnfIO f
   where

--- a/bench/Cuckoo.hs
+++ b/bench/Cuckoo.hs
@@ -43,7 +43,7 @@ main = do
             [ memberBench "1:1 hit:hiss" 10000 cf10k (interleave [5000..10000] [10001..15000])
             , memberBench "only hit" 10000 cf10k [1..10000]
             ]
-#ifdef RARANDOM_STANDARD
+#ifdef RANDOM_STANDARD
         , bgroup "delete"
             [ deleteBench "all" 10000 cf10k [1..10000]
             ]

--- a/bench/Cuckoo.hs
+++ b/bench/Cuckoo.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -42,9 +43,11 @@ main = do
             [ memberBench "1:1 hit:hiss" 10000 cf10k (interleave [5000..10000] [10001..15000])
             , memberBench "only hit" 10000 cf10k [1..10000]
             ]
+#ifdef RARANDOM_STANDARD
         , bgroup "delete"
             [ deleteBench "all" 10000 cf10k [1..10000]
             ]
+#endif
         ]
 
 -- -------------------------------------------------------------------------- --
@@ -64,14 +67,14 @@ memberBench label n cf xs = bench (label <> " - " <> show n) $ whnfIO f
   where
     f = fmap length (filterM (member cf) xs)
 
+#ifdef RARANDOM_STANDARD
 deleteBench :: String -> Int -> CuckooFilter (PrimState IO) 4 10 Int -> [Int] -> Benchmark
 deleteBench label n cf0 xs = bench (label <> " - " <> show n) $ whnfIO f
   where
     f = do
         (cf, _) <- splitCuckooFilter cf0
         fmap length (filterM (delete cf) xs)
-
-
+#endif
 
 -- | Doesn't cause actual difference in bench.
 interleave :: [a] -> [a] -> [a]

--- a/bench/Cuckoo.hs
+++ b/bench/Cuckoo.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Module: Main
+-- Copyright: Copyright © 2019-2021 Lars Kuhtz <lakuhtz@gmail.com>
+-- License: BSD3
+-- Maintainer: Lars Kuhtz <lakuhtz@gmail.com>
+-- Stability: experimental
+--
+module Main
+( main
+) where
+
+import Control.Monad (filterM)
+import Control.Monad.Primitive (PrimState)
+import Control.Monad.ST (runST)
+import Criterion
+import Criterion.Main
+import Data.Foldable (traverse_)
+
+import Data.Cuckoo
+
+-- -------------------------------------------------------------------------- --
+-- Main
+
+main :: IO ()
+main = do
+    cf10k <- do
+        cf <- newCuckooFilter @4 @10 @Int 0 12000
+        traverse_ (insert cf) [1..10000]
+        pure $! cf
+
+    defaultMain
+        [ bgroup "insert"
+            [ insertBench 10000 12000 [1..10000]
+            ]
+        , bgroup "member"
+            [ memberBench 10000 cf10k [5000..15000]
+            ]
+        ]
+
+-- -------------------------------------------------------------------------- --
+
+instance CuckooFilterHash Int
+
+insertBench :: Int -> Int -> [Int] -> Benchmark
+insertBench n cap xs0 = bench ("n-" <> show n <> "-cap-" <> show cap) $ whnf f xs0
+  where
+    f xs = runST $ do
+        cf <- newCuckooFilter @4 @10 @Int 0 (fromIntegral cap)
+        failed <- filterM (fmap not . insert cf) xs
+        pure $! length failed
+
+memberBench :: Int -> CuckooFilter (PrimState IO) 4 10 Int -> [Int] -> Benchmark
+memberBench n cf xs = bench (show n) $ whnfIO f
+  where
+    f = fmap length (filterM (member cf) xs)

--- a/cuckoo.cabal
+++ b/cuckoo.cabal
@@ -166,3 +166,22 @@ benchmark internal-benchmarks
         , base >=4.10 && <5
         , criterion >= 1.5
 
+benchmark cuckoo-benchmarks
+    type: exitcode-stdio-1.0
+    hs-source-dirs: bench
+    main-is: Cuckoo.hs
+    default-language: Haskell2010
+    ghc-options:
+        -Wall
+        -rtsopts
+        -threaded
+        -with-rtsopts=-N
+    build-depends:
+        -- internal
+        , cuckoo
+
+        -- external
+        , base >=4.10 && <5
+        , criterion >= 1.5
+        , primitive
+

--- a/cuckoo.cabal
+++ b/cuckoo.cabal
@@ -70,6 +70,7 @@ library random-internal
           , vector >=0.12
         cpp-options: -DRANDOM_MWC
     else
+        cpp-options: -DRANDOM_STANDARD
         build-depends:
           , random >=1.1
 
@@ -183,5 +184,5 @@ benchmark cuckoo-benchmarks
         -- external
         , base >=4.10 && <5
         , criterion >= 1.5
-        , primitive
+        , primitive >=0.6.4.0
 

--- a/lib/random/System/Random/Internal.hs
+++ b/lib/random/System/Random/Internal.hs
@@ -20,6 +20,7 @@ module System.Random.Internal
 , initialize
 , uniform
 , uniformR
+, genSplit
 ) where
 
 -- -------------------------------------------------------------------------- --
@@ -95,5 +96,17 @@ uniform gen = stToPrim $ do
     writeSTRef gen g
     return r
 
+-- | Odd name to avoid collision with splitGen.
+-- Using legacy 'split' name for version compatibility.
+genSplit
+    :: PrimMonad m
+    => Gen (PrimState m)
+    -> m (Gen (PrimState m), Gen (PrimState m))
+genSplit gen = stToPrim $ do
+    g <- readSTRef gen
+    let (!g0, !g1) = split g
+    s0 <- newSTRef g0
+    s1 <- newSTRef g1
+    return $ s0 `seq` s1 `seq` (s0, s1)
 #endif
 

--- a/lib/random/System/Random/Internal.hs
+++ b/lib/random/System/Random/Internal.hs
@@ -37,6 +37,12 @@ initialize
     -> m (Gen (PrimState m))
 initialize salt = PCG.initialize 0 (fromIntegral salt)
 
+genSplit
+    :: PrimMonad m
+    => Gen (PrimState m)
+    -> m (Gen (PrimState m), Gen (PrimState m))
+genSplit = error "genSplit: not available in RANDOM_PCG"
+
 -- -------------------------------------------------------------------------- --
 -- MWC
 #elif defined RANDOM_MWC
@@ -51,6 +57,12 @@ initialize
     => Int
     -> m (Gen (PrimState m))
 initialize salt = MWC.initialize (singleton $ fromIntegral salt)
+
+genSplit
+    :: PrimMonad m
+    => Gen (PrimState m)
+    -> m (Gen (PrimState m), Gen (PrimState m))
+genSplit = error "genSplit: not available in RANDOM_MWC: see https://github.com/haskell/mwc-random/issues/39"
 
 -- -------------------------------------------------------------------------- --
 -- Random

--- a/src/Data/Cuckoo.hs
+++ b/src/Data/Cuckoo.hs
@@ -377,6 +377,11 @@ splitCuckooFilter (CuckooFilter bc s rng d) = do
 -- function. If this function is used in the presence of asynchronous exceptions
 -- it should be apprioriately masked.
 --
+-- Note: if the potentially inserted elements have many repetitions, and you
+-- don't intend to delete items, rather just use the filter as a set, then it is
+-- advised to perform a 'member' check before insert. Otherwise repeated items
+-- will take up slots and cause high load or even premature insertion failure.
+--
 -- >>> f <- newCuckooFilter @4 @10 @Int 0 1000
 -- >>> insert f 0
 -- True

--- a/src/Data/Cuckoo.hs
+++ b/src/Data/Cuckoo.hs
@@ -342,7 +342,7 @@ newCuckooFilter salt n = do
 -- /IMPORTANT/ For testing purposes only - not all random lib choices support RNG state splitting.
 --
 splitCuckooFilter
-    :: PrimMonad m 
+    :: PrimMonad m
     => CuckooFilter (PrimState m) b f a
     -> m (CuckooFilter (PrimState m) b f a, CuckooFilter (PrimState m) b f a)
 splitCuckooFilter (CuckooFilter bc s rng d) = do

--- a/src/Data/Cuckoo.hs
+++ b/src/Data/Cuckoo.hs
@@ -105,11 +105,13 @@ module Data.Cuckoo
 , capacityInItems
 , itemCount
 , loadFactor
-, splitCuckooFilter
 
 -- * Debugging Utils
 , showFilter
 , itemHashes
+
+-- * Testing Utils
+, splitCuckooFilter
 ) where
 
 import Control.Applicative
@@ -337,7 +339,7 @@ newCuckooFilter salt n = do
 --
 -- This function is not thread-safe. The original CuckooFilter must not be written concurrently during the split operation.
 --
--- Mostly for testing purposes, though not restrictively.
+-- /IMPORTANT/ For testing purposes only - not all random lib choices support RNG state splitting.
 --
 splitCuckooFilter
     :: PrimMonad m 


### PR DESCRIPTION
Added benchmarks for the main public interface ops, also marked insert and delete INLINABLE, so the callsite can optimize further. This had some small but noticable impact on the benchmark.

```
insert: 16ms -> 11ms
delete: 26ms -> 16ms

```